### PR TITLE
Ability to custom outer order to work around chrome being chrome

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -22,11 +22,11 @@ var makeLine = function (type, obj, location) {
 
 // RFC specified order
 // TODO: extend this with all the rest
-var outerOrder = ['v', 'o', 's', 'i', 'u', 'e', 'p', 'c', 'b', 'z', 'a', 't', 'r'];
+var defaultOuterOrder = ['v', 'o', 's', 'i', 'u', 'e', 'p', 'c', 'b', 'z', 'a', 't', 'r'];
 var innerOrder = ['i', 'c', 'b', 'a'];
 
 
-module.exports = function (session) {
+module.exports = function (session, opts) {
   // ensure certain properties exist
   if (session.version == undefined) {
     session.version = 0; // "v=0" must be there (only defined version atm)
@@ -40,6 +40,7 @@ module.exports = function (session) {
     }
   });
 
+  var outerOrder = (opts || {}).outerOrder || defaultOuterOrder;
   var sdp = [];
 
   // loop through outerOrder for matching properties on session


### PR DESCRIPTION
This is one approach that might work for dealing with [chrome needing the t line out of order from the current RFC](https://github.com/clux/sdp-transform/issues/4#issuecomment-26643529).  

Basically added the ability for the writer to accept an optional opts argument which allows for outer order customization.
