### PR TITLE
Reneme 'sendrecv' attribute to 'direction'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ res;
        protocol: 'RTP/SAVPF',
        payloads: '0 96',
        ptime: 20,
-       sendrecv: 'sendrecv',
+       direction: 'sendrecv',
        candidates: [Object] },
      { rtp: [Object],
        fmtp: [Object],
@@ -70,7 +70,7 @@ res;
        port: 55400,
        protocol: 'RTP/SAVPF',
        payloads: '97 98',
-       sendrecv: 'sendrecv',
+       direction: 'sendrecv',
        candidates: [Object] } ] }
 
 
@@ -90,7 +90,7 @@ res.media[1];
   port: 55400,
   protocol: 'RTP/SAVPF',
   payloads: '97 98',
-  sendrecv: 'sendrecv',
+  direction: 'sendrecv',
   candidates:
    [ { foundation: 0,
        component: 1,

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -104,8 +104,9 @@ var grammar = module.exports = {
       format: "maxptime:%d"
     },
     { //a=sendrecv
-      name: 'sendrecv',
-      reg: /^(sendrecv|recvonly|sendonly|inactive)/
+      name: 'direction',
+      reg: /^(sendrecv|recvonly|sendonly|inactive)/,
+      format: "%s"
     },
     { //a=ice-ufrag:F7gI
       name: 'iceUfrag',

--- a/test/basic.js
+++ b/test/basic.js
@@ -36,7 +36,7 @@ test("normal.sdp", function (t) {
     t.equal(audio.type, "audio", "audio");
     t.equal(audio.port, 54400, "audio port");
     t.equal(audio.protocol, "RTP/SAVPF", "audio protocol");
-    t.equal(audio.sendrecv, "sendrecv", "audio sendrecv");
+    t.equal(audio.direction, "sendrecv", "audio direction");
     t.equal(audio.rtp[0].payload, 0, "audio rtp 0 payload");
     t.equal(audio.rtp[0].codec, "PCMU", "audio rtp 0 codec");
     t.equal(audio.rtp[0].rate, 8000, "audio rtp 0 rate");
@@ -58,7 +58,7 @@ test("normal.sdp", function (t) {
     t.equal(video.type, "video", "video");
     t.equal(video.port, 55400, "video port");
     t.equal(video.protocol, "RTP/SAVPF", "video protocol");
-    t.equal(video.sendrecv, "sendrecv", "video sendrecv");
+    t.equal(video.direction, "sendrecv", "video direction");
     t.equal(video.rtp[0].payload, 97, "video rtp 0 payload");
     t.equal(video.rtp[0].codec, "H264", "video rtp 0 codec");
     t.equal(video.rtp[0].rate, 90000, "video rtp 0 rate");


### PR DESCRIPTION
Hi there!

We are going to use your library in the JsSIP project, and I noticed the SDP direction attribute is stored as 'sendrecv'. This PR renames it to 'direction', as it's referred to in all SDP related RFCs.

Thanks!
