### PR TITLE
accept all newline variations

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -43,7 +43,7 @@ exports.parse = function (sdp) {
     , location = session; // points at where properties go under (one of the above)
 
   // parse lines we understand
-  sdp.split('\r\n').filter(validLine).forEach(function (l) {
+  sdp.split(/(\r\n|\r|\n)/).filter(validLine).forEach(function (l) {
     var type = l[0];
     var content = l.slice(2);
     if (type === 'm') {


### PR DESCRIPTION
"The sequence
CRLF (0x0d0a) is used to end a record, although parsers SHOULD be
tolerant and also accept records terminated with a single newline
character."

I have a commercial transcoding gateway here that spits out SDP with \n termination. I think it would be good to handle that directly.
