### PR TITLE
Allows for a space in the list of parameters for a=fmtp lines. Fixes

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -55,9 +55,11 @@ var grammar = module.exports = {
           "rtpmap:%d %s/%s";
       }
     },
-    { //a=fmtp:108 profile-level-id=24;object=23;bitrate=64000
+    {
+      //a=fmtp:108 profile-level-id=24;object=23;bitrate=64000
+      //a=fmtp:111 minptime=10; useinbandfec=1
       push: 'fmtp',
-      reg: /^fmtp:(\d*) (\S*)/,
+      reg: /^fmtp:(\d*) ((\S| )*)/,
       names: ['payload', 'config'],
       format: "fmtp:%d %s"
     },


### PR DESCRIPTION
incorrect parsing of offers from Chrome, which uses '; 'a space
character to separate parameters.

Chrome includes this line in created offers:
a=fmtp:111 minptime=10; useinbandfec=1

Parsing this loses the 'useinbandfec=1' parameter, because the reg exp does not include a space character.
I am not sure where the separator for parameters is defined (RFC4566 isn't clear about it, or at least I can't find), but the opus RTP payload type spec has [examples](https://tools.ietf.org/html/rfc7587#section-7) where parameters are indeed separated with '; '.

Including the ' ' in an offer to firefox doesn't seem to cause any problems.