### PR TITLE
Fixes tcptype with raddr and rport.

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -172,15 +172,18 @@ var grammar = module.exports = {
       //a=candidate:1162875081 1 udp 2113937151 192.168.34.75 60017 typ host generation 0
       //a=candidate:3289912957 2 udp 1845501695 193.84.77.194 60017 typ srflx raddr 192.168.34.75 rport 60017 generation 0
       //a=candidate:229815620 1 tcp 1518280447 192.168.150.19 60017 typ host tcptype active generation 0
+      //a=candidate:3289912957 2 tcp 1845501695 193.84.77.194 60017 typ srflx raddr 192.168.34.75 rport 60017 tcptype passive generation 0
       push:'candidates',
-      reg: /^candidate:(\S*) (\d*) (\S*) (\d*) (\S*) (\d*) typ (\S*)(?: tcptype (\S*))?(?: raddr (\S*) rport (\d*))?(?: generation (\d*))?/,
-      names: ['foundation', 'component', 'transport', 'priority', 'ip', 'port', 'type', 'tcptype', 'raddr', 'rport', 'generation'],
+      reg: /^candidate:(\S*) (\d*) (\S*) (\d*) (\S*) (\d*) typ (\S*)(?: raddr (\S*) rport (\d*))?(?: tcptype (\S*))?(?: generation (\d*))?/,
+      names: ['foundation', 'component', 'transport', 'priority', 'ip', 'port', 'type', 'raddr', 'rport', 'tcptype', 'generation'],
       format: function (o) {
         var str = "candidate:%s %d %s %d %s %d typ %s";
+
+        str += (o.raddr != null) ? " raddr %s rport %d" : "%v%v";
+
         // NB: candidate has three optional chunks, so %void middles one if it's missing
         str += (o.tcptype != null) ? " tcptype %s" : "%v";
 
-        str += (o.raddr != null) ? " raddr %s rport %d" : "%v%v";
         if (o.generation != null) {
           str += " generation %d";
         }


### PR DESCRIPTION
Seems tcptype is no working in the following example:
a=candidate:4 1 TCP 1688207359 192.0.2.3 9 typ srflx raddr 10.0.1.1 rport 9 tcptype active
Example taken from taken from http://tools.ietf.org/html/rfc6544#appendix-C.
(Credits to @bgrozev and @gpolitis)