### PR TITLE
add supports for candidate attr: network-id / network-cost

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -169,13 +169,13 @@ var grammar = module.exports = {
     },
     {
       //a=candidate:0 1 UDP 2113667327 203.0.113.1 54400 typ host
-      //a=candidate:1162875081 1 udp 2113937151 192.168.34.75 60017 typ host generation 0
-      //a=candidate:3289912957 2 udp 1845501695 193.84.77.194 60017 typ srflx raddr 192.168.34.75 rport 60017 generation 0
-      //a=candidate:229815620 1 tcp 1518280447 192.168.150.19 60017 typ host tcptype active generation 0
-      //a=candidate:3289912957 2 tcp 1845501695 193.84.77.194 60017 typ srflx raddr 192.168.34.75 rport 60017 tcptype passive generation 0
+      //a=candidate:1162875081 1 udp 2113937151 192.168.34.75 60017 typ host generation 0 network-id 3 network-cost 10
+      //a=candidate:3289912957 2 udp 1845501695 193.84.77.194 60017 typ srflx raddr 192.168.34.75 rport 60017 generation 0 network-id 3 network-cost 10
+      //a=candidate:229815620 1 tcp 1518280447 192.168.150.19 60017 typ host tcptype active generation 0 network-id 3 network-cost 10
+      //a=candidate:3289912957 2 tcp 1845501695 193.84.77.194 60017 typ srflx raddr 192.168.34.75 rport 60017 tcptype passive generation 0 network-id 3 network-cost 10
       push:'candidates',
-      reg: /^candidate:(\S*) (\d*) (\S*) (\d*) (\S*) (\d*) typ (\S*)(?: raddr (\S*) rport (\d*))?(?: tcptype (\S*))?(?: generation (\d*))?/,
-      names: ['foundation', 'component', 'transport', 'priority', 'ip', 'port', 'type', 'raddr', 'rport', 'tcptype', 'generation'],
+      reg: /^candidate:(\S*) (\d*) (\S*) (\d*) (\S*) (\d*) typ (\S*)(?: raddr (\S*) rport (\d*))?(?: tcptype (\S*))?(?: generation (\d*))?(?: network-id (\d*))?(?: network-cost (\d*))?/,
+      names: ['foundation', 'component', 'transport', 'priority', 'ip', 'port', 'type', 'raddr', 'rport', 'tcptype', 'generation', 'network-id', 'network-cost'],
       format: function (o) {
         var str = "candidate:%s %d %s %d %s %d typ %s";
 
@@ -187,6 +187,9 @@ var grammar = module.exports = {
         if (o.generation != null) {
           str += " generation %d";
         }
+
+        str += (o['network-id'] != null) ? " network-id %d" : "%v";
+        str += (o['network-cost'] != null) ? " network-cost %d" : "%v";
         return str;
       }
     },

--- a/test/normal.sdp
+++ b/test/normal.sdp
@@ -15,6 +15,8 @@ a=ptime:20
 a=sendrecv
 a=candidate:0 1 UDP 2113667327 203.0.113.1 54400 typ host
 a=candidate:1 2 UDP 2113667326 203.0.113.1 54401 typ host
+a=candidate:2 1 UDP 1686052607 203.0.113.1 54402 typ srflx raddr 192.168.1.145 rport 54402 generation 0 network-id 3 network-cost 10
+a=candidate:3 2 UDP 1686052606 203.0.113.1 54403 typ srflx raddr 192.168.1.145 rport 54403 generation 0 network-id 3 network-cost 10
 m=video 55400 RTP/SAVPF 97 98
 a=rtpmap:97 H264/90000
 a=fmtp:97 profile-level-id=4d0028;packetization-mode=1;sprop-parameter-sets=Z0IAH5WoFAFuQA==,aM48gA==
@@ -27,5 +29,7 @@ a=crypto:1 AES_CM_128_HMAC_SHA1_32 inline:keNcG3HezSNID7LmfDa9J4lfdUL8W1F7TNJKcb
 a=sendrecv
 a=candidate:0 1 UDP 2113667327 203.0.113.1 55400 typ host
 a=candidate:1 2 UDP 2113667326 203.0.113.1 55401 typ host
+a=candidate:2 1 UDP 1686052607 203.0.113.1 55402 typ srflx raddr 192.168.1.145 rport 55402 generation 0 network-id 3
+a=candidate:3 2 UDP 1686052606 203.0.113.1 55403 typ srflx raddr 192.168.1.145 rport 55403 generation 0 network-id 3
 a=ssrc:1399694169 foo:bar
 a=ssrc:1399694169 baz

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -101,7 +101,7 @@ exports.normalSdp = function (t) {
     [audio.candidates, video.candidates].forEach(function (cs, i) {
       var str = (i === 0) ? "audio " : "video ";
       var port = (i === 0) ? 54400 : 55400;
-      t.equal(cs.length, 2, str + "got 2 candidates");
+      t.equal(cs.length, 4, str + "got 4 candidates");
       t.equal(cs[0].foundation, 0, str + "ice candidate 0 foundation");
       t.equal(cs[0].component, 1, str + "ice candidate 0 component");
       t.equal(cs[0].transport, "UDP", str + "ice candidate 0 transport");
@@ -116,6 +116,30 @@ exports.normalSdp = function (t) {
       t.equal(cs[1].ip, "203.0.113.1", str + "ice candidate 1 ip");
       t.equal(cs[1].port, port+1, str + "ice candidate 1 port");
       t.equal(cs[1].type, "host", str + "ice candidate 1 type");
+      t.equal(cs[2].foundation, 2, str + "ice candidate 2 foundation");
+      t.equal(cs[2].component, 1, str + "ice candidate 2 component");
+      t.equal(cs[2].transport, "UDP", str + "ice candidate 2 transport");
+      t.equal(cs[2].priority, 1686052607, str + "ice candidate 2 priority");
+      t.equal(cs[2].ip, "203.0.113.1", str + "ice candidate 2 ip");
+      t.equal(cs[2].port, port+2, str + "ice candidate 2 port");
+      t.equal(cs[2].type, "srflx", str + "ice candidate 2 type");
+      t.equal(cs[2].raddr, "192.168.1.145", str + "ice candidate 2 raddr");
+      t.equal(cs[2].rport, port+2, str + "ice candidate 2 rport");
+      t.equal(cs[2].generation, 0, str + "ice candidate 2 generation");
+      t.equal(cs[2]['network-id'], 3, str + "ice candidate 2 network-id");
+      t.equal(cs[2]['network-cost'], (i === 0 ? 10 : undefined), str + "ice candidate 2 network-cost");
+      t.equal(cs[3].foundation, 3, str + "ice candidate 3 foundation");
+      t.equal(cs[3].component, 2, str + "ice candidate 3 component");
+      t.equal(cs[3].transport, "UDP", str + "ice candidate 3 transport");
+      t.equal(cs[3].priority, 1686052606, str + "ice candidate 3 priority");
+      t.equal(cs[3].ip, "203.0.113.1", str + "ice candidate 3 ip");
+      t.equal(cs[3].port, port+3, str + "ice candidate 3 port");
+      t.equal(cs[3].type, "srflx", str + "ice candidate 3 type");
+      t.equal(cs[3].raddr, "192.168.1.145", str + "ice candidate 3 raddr");
+      t.equal(cs[3].rport, port+3, str + "ice candidate 3 rport");
+      t.equal(cs[3].generation, 0, str + "ice candidate 3 generation");
+      t.equal(cs[3]['network-id'], 3, str + "ice candidate 3 network-id");
+      t.equal(cs[3]['network-cost'], (i === 0 ? 10 : undefined), str + "ice candidate 3 network-cost");
     });
 
     t.equal(media.length, 2, "got 2 m-lines");


### PR DESCRIPTION
current webrtc sdp will contain `network-id` and `network-cost` in the sdp.

#### NOTE:
these params still in draft.

**this PR only supports:**

* only `network-id` param
* only `network-cost` param
* both params with `network-id` first

**doesn't support:**

* both params with `network-cost` first

#### REASON:

the draft example shows that `network-cost` can be put before `network-id`
but the actual sdp generate by webrtc is always `netword-id` first.

also, `network-id` is mandatory, but `network-cost` can be ignored if it is 0

Draft: https://tools.ietf.org/html/draft-thatcher-ice-network-cost-01

>    3.  Choosing a value for network cost and network ID
>       Network cost is an integer in the range 0-999, where larger values
>       indicate a stronger preference for not using that network interface.
>
>       Each network interface SHOULD have a unique network ID, in the range
>       of 0 to (2^16)-1.
>
>    4.  Signaling network cost and network ID
>
>       ICE agents MUST signal network cost on each ICE candidate if the cost
>       is non-zero.  ICE agents MUST signal network ID on each ICE
>       candidate.
>
>       For example, in an SDP candidate line, the attributes could be
>       signaled as "network-cost 100 network-id 1".
