### PR TITLE
fix ssrc: ssrc suppports attribute only

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -206,9 +206,18 @@ var grammar = module.exports = {
     },
     { //a=ssrc:2566107569 cname:t9YU8M1UxTF8Y1A1
       push: "ssrcs",
-      reg: /^ssrc:(\d*) ([\w_]*):(.*)/,
+      reg: /^ssrc:(\d*) ([\w_]*)(?::(.*))?/,
       names: ['id', 'attribute', 'value'],
-      format: "ssrc:%d %s:%s"
+      format: function (o) {
+        var str = "ssrc:%d";
+        if (o.attribute != null) {
+          str += " %s";
+          if (o.value != null) {
+            str += ":%s";
+          }
+        }
+        return str;
+      }
     },
     { //a=ssrc-group:FEC 1 2
       push: "ssrcGroups",

--- a/test/normal.sdp
+++ b/test/normal.sdp
@@ -27,3 +27,5 @@ a=crypto:1 AES_CM_128_HMAC_SHA1_32 inline:keNcG3HezSNID7LmfDa9J4lfdUL8W1F7TNJKcb
 a=sendrecv
 a=candidate:0 1 UDP 2113667327 203.0.113.1 55400 typ host
 a=candidate:1 2 UDP 2113667326 203.0.113.1 55401 typ host
+a=ssrc:1399694169 foo:bar
+a=ssrc:1399694169 baz

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -84,6 +84,18 @@ exports.normalSdp = function (t) {
     t.equal(video.crypto[0].id, 1, "video crypto 0 id");
     t.equal(video.crypto[0].suite, 'AES_CM_128_HMAC_SHA1_32', "video crypto 0 suite");
     t.equal(video.crypto[0].config, 'inline:keNcG3HezSNID7LmfDa9J4lfdUL8W1F7TNJKcbuy|2^20|1:32', "video crypto 0 config");
+    t.equal(video.ssrcs.length, 2, "video got 2 ssrc lines");
+    // test ssrc with attr:value
+    t.deepEqual(video.ssrcs[0], {
+      id: 1399694169,
+      attribute: "foo",
+      value: "bar"
+    }, "video 1st ssrc line attr:value");
+    // test ssrc with attr only
+    t.deepEqual(video.ssrcs[1], {
+      id: 1399694169,
+      attribute: "baz",
+    }, "video 2nd ssrc line attr only");
 
     // ICE candidates (same for both audio and video in this case)
     [audio.candidates, video.candidates].forEach(function (cs, i) {


### PR DESCRIPTION

see #40 

ssrc can supports attribute only without value

```
 a=ssrc:<ssrc-id> <attribute>
 a=ssrc:<ssrc-id> <attribute>:<value>
```

fix #40