### PR TITLE
Fix for ssrc-group semantics parsing 

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -221,8 +221,10 @@ var grammar = module.exports = {
       }
     },
     { //a=ssrc-group:FEC 1 2
+      //a=ssrc-group:FEC-FR 3004364195 1080772241
       push: "ssrcGroups",
-      reg: /^ssrc-group:(\w*) (.*)/,
+      // token-char = %x21 / %x23-27 / %x2A-2B / %x2D-2E / %x30-39 / %x41-5A / %x5E-7E
+      reg: /^ssrc-group:([\x21\x23\x24\x25\x26\x27\x2A\x2B\x2D\x2E\w]*) (.*)/, 
       names: ['semantics', 'ssrcs'],
       format: "ssrc-group:%s %s"
     },


### PR DESCRIPTION
Fix for #53 

 ssrc-group-attr = "ssrc-group:" semantics *(SP ssrc-id)
 semantics       = "FEC" / "FID" / token
                    ; Matches RFC 3388 definition and
                    ; IANA registration rules in this doc.

 token-char =          %x21 / %x23-27 / %x2A-2B / %x2D-2E / %x30-39
                         / %x41-5A / %x5E-7E

  token =               1*(token-char)