### PR TITLE
Support for a=rid and generic params parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,13 @@ No excess parsing is done to the raw strings apart from maybe coercing to ints, 
 
 ```js
 // to parse the fmtp.config from the previous example
-transform.parseFmtpConfig(res.media[1].fmtp[0].config);
+transform.parseParams(res.media[1].fmtp[0].config);
 { 'profile-level-id': '4d0028',
   'packetization-mode': 1 }
 
 // what payloads where actually advertised in the main m-line ?
 transform.parsePayloads(res.media[1].payloads);
 [97, 98]
-
-// to parse generic params (such as those in the a=rid attribute)
-transform.parseParams(res.media[1].rids[0].params);
-{ 'pt': 97 }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ transform.parseFmtpConfig(res.media[1].fmtp[0].config);
 // what payloads where actually advertised in the main m-line ?
 transform.parsePayloads(res.media[1].payloads);
 [97, 98]
+
+// to parse generic params (such as those in the a=rid attribute)
+transform.parseParams(res.media[1].rids[0].params);
+{ 'pt': 97 }
 ```
 
 

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -263,6 +263,14 @@ var grammar = module.exports = {
       reg: /^x-google-flag:([^\s]*)/,
       format: "x-google-flag:%s"
     },
+    { //a=rid:1 send max-width=1280;max-height=720;max-fps=30;depend=0
+      push: 'rids',
+      reg: /^rid:([\d\w]+) (\w+)(?: ([\S| ]*))/,
+      names: ['id', 'direction', 'params'],
+      format: function (o) {
+        return (o.params) ? "rid:%s %s %s" : "rid:%s %s";
+      }
+    },
     { // any a= that we don't understand is kepts verbatim on media.invalid
       push: 'invalid',
       names: ["value"]

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,5 +4,6 @@ var writer = require('./writer');
 exports.write = writer;
 exports.parse = parser.parse;
 exports.parseFmtpConfig = parser.parseFmtpConfig;
+exports.parseParams = parser.parseParams;
 exports.parsePayloads = parser.parsePayloads;
 exports.parseRemoteCandidates = parser.parseRemoteCandidates;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -63,7 +63,7 @@ exports.parse = function (sdp) {
   return session;
 };
 
-var fmtpReducer = function (acc, expr) {
+var paramReducer = function (acc, expr) {
   var s = expr.split(/=(.+)/, 2);
   if (s.length === 2) {
     acc[s[0]] = toIntIfInt(s[1]);
@@ -71,9 +71,12 @@ var fmtpReducer = function (acc, expr) {
   return acc;
 };
 
-exports.parseFmtpConfig = function (str) {
-  return str.split(/\;\s?/).reduce(fmtpReducer, {});
+exports.parseParams = function (str) {
+  return str.split(/\;\s?/).reduce(paramReducer, {});
 };
+
+// For backward compatibility
+exports.parseFmtpConfig = exports.parseParams;
 
 exports.parsePayloads = function (str) {
   return str.split(' ').map(Number);

--- a/test/simulcast.sdp
+++ b/test/simulcast.sdp
@@ -1,0 +1,19 @@
+v=0
+o=alice 2362969037 2362969040 IN IP4 192.0.2.156
+s=Simulcast Enabled Client
+t=0 0
+c=IN IP4 192.0.2.156
+m=audio 49200 RTP/AVP 0
+a=rtpmap:0 PCMU/8000
+m=video 49300 RTP/AVP 97 98
+a=rtpmap:97 H264/90000
+a=rtpmap:98 H264/90000
+a=fmtp:97 profile-level-id=42c01f; max-fs=3600; max-mbps=108000
+a=fmtp:98 profile-level-id=42c00b; max-fs=240; max-mbps=3600
+a=imageattr:97 send [x=1280,y=720] recv [x=1280,y=720]
+a=imageattr:98 send [x=320,y=180] recv [x=320,y=180]
+a=rid:1 send pt=97;max-width=1280;max-height=720;max-fps=30
+a=rid:2 send pt=98
+a=rid:c recv pt=97
+a=simulcast:send 1;2 recv 3
+a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:RtpStreamId


### PR DESCRIPTION
* grammar: add `a=rid` attribute
* add a `simulcast.sdp` test
* add `exports.parseParams()` for generic attribute parameters and make `exports.parseFmtpConfig()` an alias