### PR TITLE
Add support for a=imageattr (RFC 6236)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ a=candidate:1 2 UDP 2113667326 203.0.113.1 55401 typ host\r\n\
 ";
 
 var res = transform.parse(sdpStr);
-
-res;
+// =>
 { version: 0,
   origin:
    { username: '-',
@@ -80,6 +79,7 @@ res;
 
 // each media line is parsed into the following format
 res.media[1];
+// =>
 { rtp:
    [ { payload: 97,
        codec: 'H264',
@@ -117,15 +117,38 @@ In this example, only slightly dodgy string coercion case here is for `candidate
 ### Parser Postprocessing
 No excess parsing is done to the raw strings apart from maybe coercing to ints, because the writer is built to be the inverse of the parser. That said, a few helpers have been built in:
 
+#### parseParams()
+
+Parses `fmtp.config` and others such as `rid.params` and returns an object with all the params in a key/value fashion.
+
 ```js
 // to parse the fmtp.config from the previous example
 transform.parseParams(res.media[1].fmtp[0].config);
+// =>
 { 'profile-level-id': '4d0028',
   'packetization-mode': 1 }
+```
 
+#### parsePayloads()
+
+Returns an array with all the payload advertised in the main m-line.
+
+```js
 // what payloads where actually advertised in the main m-line ?
 transform.parsePayloads(res.media[1].payloads);
+// =>
 [97, 98]
+```
+
+#### parseImageattrParams()
+
+Parses Generic Image Attributes (RFC 6236). Must be provided with the `send` string or the `recv` string of a `imageattr` line. Returns an array of key/value objects.
+
+```js
+// a=imageattr:97 send [x=1280,y=720] recv [x=1280,y=720] [x=320,y=180]
+transform.parseImageattrParams(res.media[1].imageattrs[0].recv)
+// =>
+[ {'x': 1280, 'y': 720}, {'x': 320, 'y': 180} ]
 ```
 
 
@@ -134,6 +157,7 @@ The writer is the inverse of the parser, and will need a struct equivalent to th
 
 ```js
 transform.write(res).split('\r\n'); // res parsed above
+// =>
 [ 'v=0',
   'o=- 20518 0 IN IP4 203.0.113.1',
   's= ',

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -268,6 +268,16 @@ var grammar = module.exports = {
         return (o.params) ? 'rid:%s %s %s' : 'rid:%s %s';
       }
     },
+    { //a=imageattr:97 send [x=800,y=640,sar=1.1,q=0.6] [x=480,y=320] recv [x=330,y=250]
+      //a=imageattr:* send [x=800,y=640] recv *
+      //a=imageattr:100 recv [x=320,y=240]
+      push: 'imageattrs',
+      reg: /^imageattr:(\d+|\*)(?:[\s\t]+send[\s\t]+(\*|\[\S+\](?:[\s\t]+\[\S+\])?)+)?(?:[\s\t]+recv[\s\t]+(\*|\[\S+\](?:[\s\t]+\[\S+\])?)+)?/,
+      names: ['pt', 'send', 'recv'],
+      format: function (o) {
+        return 'imageattr:%s' + (o.send ? ' send %s' : '%v') + (o.recv ? ' recv %s' : '%v');
+      }
+    },
     { // any a= that we don't understand is kepts verbatim on media.invalid
       push: 'invalid',
       names: ['value']

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -272,7 +272,14 @@ var grammar = module.exports = {
       //a=imageattr:* send [x=800,y=640] recv *
       //a=imageattr:100 recv [x=320,y=240]
       push: 'imageattrs',
-      reg: /^imageattr:(\d+|\*)(?:[\s\t]+send[\s\t]+(\*|\[\S+\](?:[\s\t]+\[\S+\])?)+)?(?:[\s\t]+recv[\s\t]+(\*|\[\S+\](?:[\s\t]+\[\S+\])?)+)?/,
+      reg: new RegExp(
+        //a=imageattr:97
+        '^imageattr:(\\d+|\\*)' +
+        //send [x=800,y=640,sar=1.1,q=0.6] [x=480,y=320]
+        '(?:[\\s\\t]+send[\\s\\t]+(\\*|\\[\\S+\\](?:[\\s\\t]+\\[\\S+\\])?)+)?' +
+        //recv [x=330,y=250]
+        '(?:[\\s\\t]+recv[\\s\\t]+(\\*|\\[\\S+\\](?:[\\s\\t]+\\[\\S+\\])?)+)?'
+      ),
       names: ['pt', 'send', 'recv'],
       format: function (o) {
         return 'imageattr:%s' + (o.send ? ' send %s' : '%v') + (o.recv ? ' recv %s' : '%v');

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,5 +5,6 @@ exports.write = writer;
 exports.parse = parser.parse;
 exports.parseFmtpConfig = parser.parseFmtpConfig;
 exports.parseParams = parser.parseParams;
+exports.parseImageattrParams = parser.parseImageattrParams;
 exports.parsePayloads = parser.parsePayloads;
 exports.parseRemoteCandidates = parser.parseRemoteCandidates;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -75,6 +75,18 @@ exports.parseParams = function (str) {
   return str.split(/\;\s?/).reduce(paramReducer, {});
 };
 
+exports.parseImageattrParams = function (str) {
+  var list = [];
+
+  str.split(' ').forEach(function (item) {
+    var params = item.substring(1, item.length-1).split(',').reduce(paramReducer, {});
+
+    list.push(params);
+  });
+
+  return list;
+};
+
 // For backward compatibility
 exports.parseFmtpConfig = exports.parseParams;
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -76,15 +76,9 @@ exports.parseParams = function (str) {
 };
 
 exports.parseImageattrParams = function (str) {
-  var list = [];
-
-  str.split(' ').forEach(function (item) {
-    var params = item.substring(1, item.length-1).split(',').reduce(paramReducer, {});
-
-    list.push(params);
+  return str.split(' ').map(function (item) {
+    return item.substring(1, item.length-1).split(',').reduce(paramReducer, {});
   });
-
-  return list;
 };
 
 // For backward compatibility

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -22,8 +22,8 @@ var sdps = [
   'jsep.sdp',
   //'alac.sdp', // deliberate invalids
   //'onvif.sdp', // SHOULD PASS
-  'ssrc.sdp',
-  //'simulcast.sdp', (imageattr not yet valid)
+  'ssrc.sdp'
+  //'simulcast.sdp', (a=simulcast not yet implemented)
 ];
 
 sdps.forEach((name) => {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -5,6 +5,7 @@ var fs = require('co-fs')
   , write = main.write
   , parseFmtpConfig = main.parseFmtpConfig
   , parseParams = main.parseParams
+  , parseImageattrParams = main.parseImageattrParams
   ;
 
 // some random sdp that keps having random attributes attached to it
@@ -448,7 +449,9 @@ test('simulcastSdp', function *(t) {
 
   var video = media[1];
   t.equal(video.type, 'video', 'video type');
-  t.equal(video.rids.length, 3, 'video got 3 rid lines');
+
+  // test rid lines
+  t.equal(video.rids.length, 4, 'video got 4 rid lines');
   // test rid 1
   t.deepEqual(video.rids[0], {
     id: 1,
@@ -463,10 +466,16 @@ test('simulcastSdp', function *(t) {
   }, 'video 2nd rid line');
   // test rid 3
   t.deepEqual(video.rids[2], {
+    id: 3,
+    direction: 'send',
+    params: 'pt=99'
+  }, 'video 3rd rid line');
+  // test rid 4
+  t.deepEqual(video.rids[3], {
     id: 'c',
     direction: 'recv',
     params: 'pt=97'
-  }, 'video 3rd rid line');
+  }, 'video 3th rid line');
   // test rid 1 params
   var rid1Params = parseParams(video.rids[0].params);
   t.deepEqual(rid1Params, {
@@ -483,6 +492,58 @@ test('simulcastSdp', function *(t) {
   // test rid 3 params
   var rid3Params = parseParams(video.rids[2].params);
   t.deepEqual(rid3Params, {
-    'pt': 97
+    'pt': 99
   }, 'video 3rd rid params');
+  // test rid 4 params
+  var rid4Params = parseParams(video.rids[3].params);
+  t.deepEqual(rid4Params, {
+    'pt': 97
+  }, 'video 4th rid params');
+
+  // test imageattr lines
+  t.equal(video.imageattrs.length, 4, 'video got 4 imageattr lines');
+  // test imageattr 1
+  t.deepEqual(video.imageattrs[0], {
+    pt: 97,
+    send: '[x=1280,y=720]',
+    recv: '[x=1280,y=720] [x=320,y=180]'
+  }, 'video 1st imageattr line');
+  // test imageattr 2
+  t.deepEqual(video.imageattrs[1], {
+    pt: 98,
+    send: '[x=320,y=180]'
+  }, 'video 2nd imageattr line');
+  // test imageattr 3
+  t.deepEqual(video.imageattrs[2], {
+    pt: 99,
+    send: '[x=160,y=90]'
+  }, 'video 3rd imageattr line');
+  // test imageattr 4
+  t.deepEqual(video.imageattrs[3], {
+    pt: '*',
+    recv: '*'
+  }, 'video 4th imageattr line');
+  // test imageattr 1 send params
+  var imageattr1SendParams = parseImageattrParams(video.imageattrs[0].send);
+  t.deepEqual(imageattr1SendParams, [
+    {'x': 1280, 'y': 720}
+  ], 'video 1st imageattr send params');
+  // test imageattr 1 recv params
+  var imageattr1RecvParams = parseImageattrParams(video.imageattrs[0].recv);
+  t.deepEqual(imageattr1RecvParams, [
+    {'x': 1280, 'y': 720},
+    {'x': 320, 'y': 180},
+  ], 'video 1st imageattr recv params');
+  // test imageattr 2 send params
+  var imageattr2SendParams = parseImageattrParams(video.imageattrs[1].send);
+  t.deepEqual(imageattr2SendParams, [
+    {'x': 320, 'y': 180}
+  ], 'video 2nd imageattr send params');
+  // test imageattr 3 send params
+  var imageattr3SendParams = parseImageattrParams(video.imageattrs[2].send);
+  t.deepEqual(imageattr3SendParams, [
+    {'x': 160, 'y': 90}
+  ], 'video 3rd imageattr send params');
+  // test imageattr 4 recv params
+  t.equal(video.imageattrs[3].recv, '*', 'video 4th imageattr recv params');
 });

--- a/test/simulcast.sdp
+++ b/test/simulcast.sdp
@@ -8,12 +8,17 @@ a=rtpmap:0 PCMU/8000
 m=video 49300 RTP/AVP 97 98
 a=rtpmap:97 H264/90000
 a=rtpmap:98 H264/90000
+a=rtpmap:99 H264/90000
 a=fmtp:97 profile-level-id=42c01f; max-fs=3600; max-mbps=108000
 a=fmtp:98 profile-level-id=42c00b; max-fs=240; max-mbps=3600
-a=imageattr:97 send [x=1280,y=720] recv [x=1280,y=720]
-a=imageattr:98 send [x=320,y=180] recv [x=320,y=180]
+a=fmtp:99 profile-level-id=42c00b; max-fs=120; max-mbps=1800
+a=imageattr:97 send [x=1280,y=720] recv [x=1280,y=720] [x=320,y=180]
+a=imageattr:98 send [x=320,y=180]
+a=imageattr:99 send [x=160,y=90]
+a=imageattr:* recv *
 a=rid:1 send pt=97;max-width=1280;max-height=720;max-fps=30
 a=rid:2 send pt=98
+a=rid:3 send pt=99
 a=rid:c recv pt=97
-a=simulcast:send 1;2 recv 3
+a=simulcast:send 1;2;3 recv 3
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:RtpStreamId

--- a/test/simulcast.sdp
+++ b/test/simulcast.sdp
@@ -20,5 +20,5 @@ a=rid:1 send pt=97;max-width=1280;max-height=720;max-fps=30
 a=rid:2 send pt=98
 a=rid:3 send pt=99
 a=rid:c recv pt=97
-a=simulcast:send 1;2;3 recv 3
+a=simulcast:send 1;2;3 recv c
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:RtpStreamId


### PR DESCRIPTION
- grammar: add `imageattrs` for `a=imageattr` lines (RFC 6236)
- add `export.parseImageattrParams()`
