### PR TITLE
Add support for ssrc attributes with dashes.

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -204,7 +204,7 @@ var grammar = module.exports = {
     },
     { //a=ssrc:2566107569 cname:t9YU8M1UxTF8Y1A1
       push: 'ssrcs',
-      reg: /^ssrc:(\d*) ([\w_]*)(?::(.*))?/,
+      reg: /^ssrc:(\d*) ([\w_-]*)(?::(.*))?/,
       names: ['id', 'attribute', 'value'],
       format: function (o) {
         var str = 'ssrc:%d';

--- a/test/normal.sdp
+++ b/test/normal.sdp
@@ -33,3 +33,4 @@ a=candidate:2 1 UDP 1686052607 203.0.113.1 55402 typ srflx raddr 192.168.1.145 r
 a=candidate:3 2 UDP 1686052606 203.0.113.1 55403 typ srflx raddr 192.168.1.145 rport 55403 generation 0 network-id 3
 a=ssrc:1399694169 foo:bar
 a=ssrc:1399694169 baz
+a=ssrc:1399694169 foo-bar:baz

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -86,7 +86,7 @@ test('normalSdp', function *(t) {
   t.equal(video.crypto[0].id, 1, 'video crypto 0 id');
   t.equal(video.crypto[0].suite, 'AES_CM_128_HMAC_SHA1_32', 'video crypto 0 suite');
   t.equal(video.crypto[0].config, 'inline:keNcG3HezSNID7LmfDa9J4lfdUL8W1F7TNJKcbuy|2^20|1:32', 'video crypto 0 config');
-  t.equal(video.ssrcs.length, 2, 'video got 2 ssrc lines');
+  t.equal(video.ssrcs.length, 3, 'video got 3 ssrc lines');
   // test ssrc with attr:value
   t.deepEqual(video.ssrcs[0], {
     id: 1399694169,
@@ -98,6 +98,12 @@ test('normalSdp', function *(t) {
     id: 1399694169,
     attribute: 'baz',
   }, 'video 2nd ssrc line attr only');
+  // test ssrc with at-tr:value
+  t.deepEqual(video.ssrcs[2], {
+    id: 1399694169,
+    attribute: 'foo-bar',
+    value: 'baz'
+  }, 'video 3rd ssrc line attr with dash');
 
   // ICE candidates (same for both audio and video in this case)
   [audio.candidates, video.candidates].forEach(function (cs, i) {


### PR DESCRIPTION
Ran into a scenario where a `a=ssrc` line was not being parsed properly; the regex was not checking for `-` characters. The `ssrc` attribute in question is `previous-ssrc` ([RFC 5576](https://tools.ietf.org/html/rfc5576#section-6.2)).

This change modifies the `ssrc` grammar regex to allow for `-` in the attribute name, and adds a test case for it.