### PR TITLE
add support for source-filter (ex: 'a=source-filter: incl IN IP4 239.5.2.31 10.1.15.5')

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -319,6 +319,13 @@ var grammar = module.exports = {
       reg: /^framerate:(\d+(?:$|\.\d+))/,
       format: 'framerate:%s'
     },
+    { // RFC4570
+      //a=source-filter: incl IN IP4 239.5.2.31 10.1.15.5
+      name: 'sourceFilter',
+      reg: /^source-filter: *(excl|incl) (\S*) (IP4|IP6|\*) (\S*) (.*)/,
+      names: ['filterMode', 'netType', 'addressTypes', 'destAddress', 'srcList'],
+      format: 'source-filter: %s %s %s %s %s'
+    },
     { // any a= that we don't understand is kepts verbatim on media.invalid
       push: 'invalid',
       names: ['value']

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -620,3 +620,20 @@ test('simulcastSdp', function *(t) {
     value: 'send rid=1,4;2;3 paused=4 recv rid=c'
   }, 'video simulcast draft 03 line');
 });
+
+test('ST2022-6', function *(t) {
+  var sdp = yield fs.readFile(__dirname + '/st2022-6.sdp', 'utf8');
+
+  var session = parse(sdp+'');
+  t.ok(session, 'got session info');
+  var media = session.media;
+  t.ok(media && media.length > 0, 'got media');
+
+  var video = media[0];
+  var sourceFilter = video.sourceFilter;
+  t.equal(sourceFilter.filterMode, 'incl', 'filter-mode is "incl"');
+  t.equal(sourceFilter.netType, 'IN', 'nettype is "IN"');
+  t.equal(sourceFilter.addressTypes, 'IP4', 'address-type is "IP4"');
+  t.equal(sourceFilter.destAddress, '239.0.0.1', 'dest-address is "239.0.0.1"');
+  t.equal(sourceFilter.srcList, '192.168.20.20', 'src-list is "192.168.20.20"');
+});

--- a/test/st2022-6.sdp
+++ b/test/st2022-6.sdp
@@ -1,0 +1,8 @@
+v=0
+o=- 198403 11 IN IP4 192.168.20.20
+s=st2022-6 source
+t=0 0
+m=video 2004 RTP/AVP 98
+c=IN IP4 239.0.0.1/32
+a=rtpmap:98 SMPTE2022-6/27000000
+a=source-filter: incl IN IP4 239.0.0.1 192.168.20.20


### PR DESCRIPTION
grammar.js was missing an entry for "source-filter" as defined in RFC4570.

Last group in regex is a little bit greedy, but the RFC define it as "one or more unicast addresses or FQDNs, separated by space characters". 
I'm not a regex warrior, feel free to find a better implementation for that ;-)