### PR TITLE
parsePayloads() is not safe

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -81,7 +81,7 @@ exports.parseParams = function (str) {
 exports.parseFmtpConfig = exports.parseParams;
 
 exports.parsePayloads = function (str) {
-  return str.split(' ').map(Number);
+  return str.toString().split(' ').map(Number);
 };
 
 exports.parseRemoteCandidates = function (str) {


### PR DESCRIPTION
If there's only a payload in the m= line is considered as number and the function split throws an error.
Should check the other functions too