### PR TITLE
Add support for encrypted header extensions (RFC 6904)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SDP Transform
+
 [![npm status](http://img.shields.io/npm/v/sdp-transform.svg)](https://www.npmjs.org/package/sdp-transform)
 [![build status](https://secure.travis-ci.org/clux/sdp-transform.svg)](http://travis-ci.org/clux/sdp-transform)
 [![dependency status](https://david-dm.org/clux/sdp-transform.svg)](https://david-dm.org/clux/sdp-transform)
@@ -10,6 +11,7 @@ For simplicity it will force values that are integers to integers and leave ever
 
 
 ## Usage - Parser
+
 Require it and pass it an unprocessed SDP string.
 
 ```js
@@ -115,6 +117,7 @@ res.media[1];
 In this example, only slightly dodgy string coercion case here is for `candidates[i].foundation`, which can be a string, but in this case can be equally parsed as an integer.
 
 ### Parser Postprocessing
+
 No excess parsing is done to the raw strings apart from maybe coercing to ints, because the writer is built to be the inverse of the parser. That said, a few helpers have been built in:
 
 #### parseParams()
@@ -175,6 +178,7 @@ transform.parseSimulcastStreamList(res.media[1].simulcast.attrs1);
 ```
 
 ## Usage - Writer
+
 The writer is the inverse of the parser, and will need a struct equivalent to the one returned by it.
 
 ```js
@@ -206,7 +210,9 @@ transform.write(res).split('\r\n'); // res parsed above
 
 The only thing different from the original input is we follow the order specified by the SDP RFC, and we will always do so.
 
+
 ## Installation
+
 Install locally from npm:
 
 ```bash
@@ -214,4 +220,5 @@ $ npm install sdp-transform
 ```
 
 ## License
+
 MIT-Licensed. See LICENSE file for details.

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -109,11 +109,18 @@ var grammar = module.exports = {
     {
       // a=extmap:2 urn:ietf:params:rtp-hdrext:toffset
       // a=extmap:1/recvonly URI-gps-string
+      // a=extmap:3 urn:ietf:params:rtp-hdrext:encrypt urn:ietf:params:rtp-hdrext:smpte-tc 25@600/24
       push: 'ext',
-      reg: /^extmap:(\d+)(?:\/(\w+))? (\S*)(?: (\S*))?/,
-      names: ['value', 'direction', 'uri', 'config'],
+      reg: /^extmap:(\d+)(?:\/(\w+))?(?: (urn:ietf:params:rtp-hdrext:encrypt))? (\S*)(?: (\S*))?/,
+      names: ['value', 'direction', 'encrypt-uri', 'uri', 'config'],
       format: function (o) {
-        return 'extmap:%d' + (o.direction ? '/%s' : '%v') + ' %s' + (o.config ? ' %s' : '');
+        return (
+          'extmap:%d' +
+          (o.direction ? '/%s' : '%v') +
+          (o['encrypt-uri'] ? ' %s' : '%v') +
+          ' %s' +
+          (o.config ? ' %s' : '')
+        );
       }
     },
     {
@@ -392,7 +399,7 @@ var grammar = module.exports = {
       format: 'max-message-size:%s'
     },
     {
-      // any a= that we don't understand is kepts verbatim on media.invalid
+      // any a= that we don't understand is kept verbatim on media.invalid
       push: 'invalid',
       names: ['value']
     }

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -26,6 +26,8 @@ var verifyCompose = function *(file, t) {
 var sdps = [
   'normal.sdp',
   'hacky.sdp',
+  'icelite.sdp',
+  'invalid.sdp',
   'jssip.sdp',
   'jsep.sdp',
   'alac.sdp',
@@ -34,6 +36,8 @@ var sdps = [
   'simulcast.sdp',
   'st2022-6.sdp',
   'st2110-20.sdp',
+  'sctp-dtls-26.sdp',
+  'extmap-encrypt.sdp'
 ];
 
 sdps.forEach((name) => {

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -18,12 +18,17 @@ var verifyCoverage = function *(file, t) {
 var sdps = [
   'normal.sdp',
   'hacky.sdp',
+  'icelite.sdp',
   'jssip.sdp',
   'jsep.sdp',
-  //'alac.sdp', // deliberate invalids
-  //'onvif.sdp', // SHOULD PASS
+  // 'alac.sdp', // deliberate invalids
+  'onvif.sdp',
   'ssrc.sdp',
-  'simulcast.sdp'
+  'simulcast.sdp',
+  'st2022-6.sdp',
+  // 'st2110-20.sdp', // deliberate invalids
+  'sctp-dtls-26.sdp',
+  'extmap-encrypt.sdp'
 ];
 
 sdps.forEach((name) => {

--- a/test/extmap-encrypt.sdp
+++ b/test/extmap-encrypt.sdp
@@ -1,0 +1,11 @@
+v=0
+o=- 20518 0 IN IP4 203.0.113.1
+s=
+t=0 0
+c=IN IP4 203.0.113.1
+m=audio 54400 RTP/SAVPF 96
+a=rtpmap:96 opus/48000
+a=extmap:1/sendonly URI-toffset
+a=extmap:2 urn:ietf:params:rtp-hdrext:toffset
+a=extmap:3 urn:ietf:params:rtp-hdrext:encrypt urn:ietf:params:rtp-hdrext:smpte-tc 25@600/24
+a=extmap:4/recvonly urn:ietf:params:rtp-hdrext:encrypt URI-gps-string

--- a/test/icelite.sdp
+++ b/test/icelite.sdp
@@ -9,7 +9,6 @@ a=rtpmap:8 PCMA/8000
 a=rtpmap:0 PCMU/8000
 a=rtpmap:101 telephone-event/8000
 a=fmtp:101 0-15
-a=direction:both
 a=sendrecv
 a=rtcp-mux
 a=setup:actpass

--- a/test/onvif.sdp
+++ b/test/onvif.sdp
@@ -8,5 +8,4 @@ a=control:rtsp://example.com/onvif_camera/video
 m=application 0 RTP/AVP 107
 a=control:rtsp://example.com/onvif_camera/metadata
 a=recvonly
-a=rtpmap
 a=rtpmap:107 vnd.onvif.metadata/90000


### PR DESCRIPTION
`ext` entries get a new 'encrypt-uri' field which must be 'urn:ietf:params:rtp-hdrext:encrypt', meaning that the `a=extmap` entry indicates an encrypted header extension.

Some minor improvements have also been done, such as including missing SDP files in coverage tests.