### PR TITLE
Add support for a=keywds

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -399,6 +399,12 @@ var grammar = module.exports = {
       format: 'max-message-size:%s'
     },
     {
+      // a=keywds:keywords
+      name: 'keywords',
+      reg: /^keywds:(.+)$/,
+      format: 'keywds:%s'
+    },
+    {
       // any a= that we don't understand is kept verbatim on media.invalid
       push: 'invalid',
       names: ['value']

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -37,7 +37,8 @@ var sdps = [
   'st2022-6.sdp',
   'st2110-20.sdp',
   'sctp-dtls-26.sdp',
-  'extmap-encrypt.sdp'
+  'extmap-encrypt.sdp',
+  'dante-aes67.sdp'
 ];
 
 sdps.forEach((name) => {

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -28,7 +28,8 @@ var sdps = [
   'st2022-6.sdp',
   // 'st2110-20.sdp', // deliberate invalids
   'sctp-dtls-26.sdp',
-  'extmap-encrypt.sdp'
+  'extmap-encrypt.sdp',
+  'dante-aes67.sdp'
 ];
 
 sdps.forEach((name) => {

--- a/test/dante-aes67.sdp
+++ b/test/dante-aes67.sdp
@@ -1,0 +1,11 @@
+v=0
+o=- 1423986 1423994 IN IP4 169.254.98.63
+s=AOIP44-serial-1614 : 2
+c=IN IP4 239.65.125.63/32
+t=0 0
+a=keywds:Dante
+m=audio 5004 RTP/AVP 97
+i=2 channels: TxChan 0, TxChan 1
+a=recvonly
+a=rtpmap:97 L24/48000/2
+a=ptime:1

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -752,3 +752,37 @@ test('extmapEncryptSdp', function *(t) {
 
   t.equal(media.length, 1, 'got 1 m-lines');
 });
+
+test('dante-aes67', function *(t) {
+  var sdp = yield fs.readFile(__dirname + '/dante-aes67.sdp', 'utf8');
+
+  var session = parse(sdp+'');
+  t.ok(session, 'got session info');
+  var media = session.media;
+  t.ok(media && media.length == 1, 'got single media');
+
+  t.equal(session.origin.username, '-', 'origin username');
+  t.equal(session.origin.sessionId, 1423986, 'origin sessionId');
+  t.equal(session.origin.sessionVersion, 1423994, 'origin sessionVersion');
+  t.equal(session.origin.netType, 'IN', 'origin netType');
+  t.equal(session.origin.ipVer, 4, 'origin ipVer');
+  t.equal(session.origin.address, '169.254.98.63', 'origin address');
+
+  t.equal(session.name, 'AOIP44-serial-1614 : 2', 'Session Name');
+  t.equal(session.keywords, 'Dante', 'Keywords');
+
+  t.equal(session.connection.ip, '239.65.125.63/32', 'session connect ip');
+  t.equal(session.connection.version, 4, 'session connect ip ver');
+
+  var audio = media[0];
+  t.equal(audio.type, 'audio', 'audio type');
+  t.equal(audio.port, 5004, 'audio port');
+  t.equal(audio.protocol, 'RTP/AVP', 'audio protocol');
+  t.equal(audio.direction, 'recvonly', 'audio direction');
+  t.equal(audio.description, '2 channels: TxChan 0, TxChan 1', 'audio description');
+  t.equal(audio.ptime, 1, 'audio packet duration');
+  t.equal(audio.rtp[0].payload, 97, 'audio rtp payload type');
+  t.equal(audio.rtp[0].codec, 'L24', 'audio rtp codec');
+  t.equal(audio.rtp[0].rate, 48000, 'audio sample rate');
+  t.equal(audio.rtp[0].encoding, 2, 'audio channels');
+});


### PR DESCRIPTION
`a=keywds` is specified in [RFC4566](https://tools.ietf.org/html/rfc4566).
It is a session-level attribute.

The example SDP file was generated by a [Glensound AoIP44](https://www.glensound.co.uk/product-details/aoip44/) in [AES67 mode](https://en.wikipedia.org/wiki/AES67), which has a Dante Ultimo X4 chipset.

Note that the SDP also contains the following two lines. I will raise a further PR to add support for them:
```
a=ts-refclk:ptp=IEEE1588-2008:00-00-00-FF-FE-00-00-00:0
a=mediaclk:direct=3560866135
```

Full SDP in Gist here:
https://gist.github.com/njh/90e8b7f44f5c79a76a5e12cc922220c6
