### PR TITLE
Added support for RFC4145 (TCP-Based Media Transport)

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -141,6 +141,12 @@ var grammar = module.exports = {
       format: 'setup:%s'
     },
     {
+      // a=connection:new
+      name: 'connectionType',
+      reg: /^connection:(new|existing)/,
+      format: 'connection:%s'
+    },
+    {
       // a=mid:1
       name: 'mid',
       reg: /^mid:([^\s]*)/,

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -38,7 +38,9 @@ var sdps = [
   'st2110-20.sdp',
   'sctp-dtls-26.sdp',
   'extmap-encrypt.sdp',
-  'dante-aes67.sdp'
+  'dante-aes67.sdp',
+  'tcp-active.sdp',
+  'tcp-passive.sdp'
 ];
 
 sdps.forEach((name) => {

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -29,7 +29,9 @@ var sdps = [
   // 'st2110-20.sdp', // deliberate invalids
   'sctp-dtls-26.sdp',
   'extmap-encrypt.sdp',
-  'dante-aes67.sdp'
+  'dante-aes67.sdp',
+  'tcp-active.sdp',
+  'tcp-passive.sdp'
 ];
 
 sdps.forEach((name) => {

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -786,3 +786,56 @@ test('dante-aes67', function *(t) {
   t.equal(audio.rtp[0].rate, 48000, 'audio sample rate');
   t.equal(audio.rtp[0].encoding, 2, 'audio channels');
 });
+
+
+test('tcp-active', function *(t) {
+  var sdp = yield fs.readFile(__dirname + '/tcp-active.sdp', 'utf8');
+
+  var session = parse(sdp+'');
+  t.ok(session, 'got session info');
+  var media = session.media;
+  t.ok(media && media.length == 1, 'got single media');
+
+  t.equal(session.origin.username, '-', 'origin username');
+  t.equal(session.origin.sessionId, 1562876543, 'origin sessionId');
+  t.equal(session.origin.sessionVersion, 11, 'origin sessionVersion');
+  t.equal(session.origin.netType, 'IN', 'origin netType');
+  t.equal(session.origin.ipVer, 4, 'origin ipVer');
+  t.equal(session.origin.address, '192.0.2.3', 'origin address');
+
+  var image = media[0];
+  t.equal(image.type, 'image', 'image type');
+  t.equal(image.port, 9, 'port');
+  t.equal(image.connection.version, 4, 'Connection is IPv4');
+  t.equal(image.connection.ip, '192.0.2.3', 'Connection address');
+  t.equal(image.protocol, 'TCP', 'TCP protocol');
+  t.equal(image.payloads, 't38', 'TCP payload');
+  t.equal(image.setup, 'active', 'setup active');
+  t.equal(image.connectionType, 'new', 'new connection');
+});
+
+test('tcp-passive', function *(t) {
+  var sdp = yield fs.readFile(__dirname + '/tcp-passive.sdp', 'utf8');
+
+  var session = parse(sdp+'');
+  t.ok(session, 'got session info');
+  var media = session.media;
+  t.ok(media && media.length == 1, 'got single media');
+
+  t.equal(session.origin.username, '-', 'origin username');
+  t.equal(session.origin.sessionId, 1562876543, 'origin sessionId');
+  t.equal(session.origin.sessionVersion, 11, 'origin sessionVersion');
+  t.equal(session.origin.netType, 'IN', 'origin netType');
+  t.equal(session.origin.ipVer, 4, 'origin ipVer');
+  t.equal(session.origin.address, '192.0.2.2', 'origin address');
+
+  var image = media[0];
+  t.equal(image.type, 'image', 'image type');
+  t.equal(image.port, 54111, 'port');
+  t.equal(image.connection.version, 4, 'Connection is IPv4');
+  t.equal(image.connection.ip, '192.0.2.2', 'Connection address');
+  t.equal(image.protocol, 'TCP', 'TCP protocol');
+  t.equal(image.payloads, 't38', 'TCP payload');
+  t.equal(image.setup, 'passive', 'setup passive');
+  t.equal(image.connectionType, 'existing', 'existing connection');
+});

--- a/test/tcp-active.sdp
+++ b/test/tcp-active.sdp
@@ -1,0 +1,7 @@
+v=0
+o=- 1562876543 11 IN IP4 192.0.2.3
+s=RFC4145 Example 7.4.2
+m=image 9 TCP t38
+c=IN IP4 192.0.2.3
+a=setup:active
+a=connection:new

--- a/test/tcp-passive.sdp
+++ b/test/tcp-passive.sdp
@@ -1,0 +1,7 @@
+v=0
+o=- 1562876543 11 IN IP4 192.0.2.2
+s=RFC4145 Example 7.3.1
+m=image 54111 TCP t38
+c=IN IP4 192.0.2.2
+a=setup:passive
+a=connection:existing


### PR DESCRIPTION
This Pull Request adds support for RFC4145 (TCP-Based Media Transport) to the grammar.

* `a=setup` was already in grammar.js
* I added `a=connection`, with 'new' and 'existing' as valid values
* I had to name the JavaScript property 'connectionType', because `c=` was getting written to `connection`
* Added a couple of example SDP files from based on the examples in RFC4145

Fixes #55