### PR TITLE
Add support for a=extmap-allow-mixed (RFC 8285)

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -124,6 +124,11 @@ var grammar = module.exports = {
       }
     },
     {
+      // a=extmap-allow-mixed
+      name: 'extmapAllowMixed',
+      reg: /^(extmap-allow-mixed)/
+    },
+    {
       // a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:PS1uQCVeeCFCanVmcjkpPywjNWhcYD0mXXtxaVBR|2^20|1:32
       push: 'crypto',
       reg: /^crypto:(\d*) ([\w_]*) (\S*)(?: (\S*))?/,

--- a/test/normal.sdp
+++ b/test/normal.sdp
@@ -11,6 +11,7 @@ a=rtpmap:0 PCMU/8000
 a=rtpmap:96 opus/48000
 a=extmap:1 URI-toffset
 a=extmap:2/recvonly URI-gps-string
+a=extmap-allow-mixed
 a=ptime:20
 a=sendrecv
 a=candidate:0 1 UDP 2113667327 203.0.113.1 54400 typ host

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -51,6 +51,7 @@ test('normalSdp', function *(t) {
     direction: 'recvonly',
     uri: 'URI-gps-string'
   }, 'audio extension 1');
+  t.equal(audio.extmapAllowMixed, 'extmap-allow-mixed', 'extmap-allow-mixed present');
 
   var video = media[1];
   t.equal(video.type, 'video', 'video type');


### PR DESCRIPTION
New media section attribute: `extmapAllowMixed`.

* Spec: https://tools.ietf.org/html/rfc8285#section-6

* Reading:

```js
if (media[0].extmapAllowMixed)
{
  // [...]
}
```

* Writing:

```js
media[0].extmapAllowMixed = 'extmap-allow-mixed';
```