### PR TITLE
Feature - Add support for sub 1ms packet time

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -166,13 +166,13 @@ var grammar = module.exports = {
     {
       // a=ptime:20
       name: 'ptime',
-      reg: /^ptime:(\d*)/,
+      reg: /^ptime:(\d*(?:\.\d*)*)/,
       format: 'ptime:%d'
     },
     {
       // a=maxptime:60
       name: 'maxptime',
-      reg: /^maxptime:(\d*)/,
+      reg: /^maxptime:(\d*(?:\.\d*)*)/,
       format: 'maxptime:%d'
     },
     {

--- a/test/hacky.sdp
+++ b/test/hacky.sdp
@@ -34,6 +34,7 @@ a=rtpmap:106 CN/32000
 a=rtpmap:105 CN/16000
 a=rtpmap:13 CN/8000
 a=rtpmap:126 telephone-event/8000
+a=ptime:0.125
 a=maxptime:60
 a=ssrc:2754920552 cname:t9YU8M1UxTF8Y1A1
 a=ssrc:2754920552 msid:Jvlam5X3SX1OP6pn20zWogvaKJz5Hjf9OnlV Jvlam5X3SX1OP6pn20zWogvaKJz5Hjf9OnlVa0

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -213,6 +213,7 @@ test('hackySdp', function *(t) {
 
 
   t.equal(media[0].iceOptions, 'google-ice', 'ice options parsed');
+  t.equal(media[0].ptime, 0.125, 'audio packet duration');
   t.equal(media[0].maxptime, 60, 'maxptime parsed');
   t.equal(media[0].rtcpMux, 'rtcp-mux', 'rtcp-mux present');
 


### PR DESCRIPTION
RFC-4566 states that `ptime` represents packet time in milliseconds, however I work with hardware that supports 110µs, 125µs, 1ms packet times which are being parsed as int's.