### PR TITLE
Fix rtcp-fb format for trr-int value

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -93,7 +93,7 @@ var grammar = module.exports = {
       push: 'rtcpFbTrrInt',
       reg: /^rtcp-fb:(\*|\d*) trr-int (\d*)/,
       names: ['payload', 'value'],
-      format: 'rtcp-fb:%d trr-int %d'
+      format: 'rtcp-fb:%s trr-int %d'
     },
     {
       // a=rtcp-fb:98 nack rpsi

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -47,7 +47,8 @@ var sdps = [
   'mediaclk-ptp-v2.sdp',
   'mediaclk-rtp.sdp',
   'ts-refclk-media.sdp',
-  'ts-refclk-sess.sdp'
+  'ts-refclk-sess.sdp',
+  'rtcp-fb.sdp'
 ];
 
 sdps.forEach((name) => {

--- a/test/coverage.test.js
+++ b/test/coverage.test.js
@@ -38,7 +38,8 @@ var sdps = [
   'mediaclk-ptp-v2.sdp',
   'mediaclk-rtp.sdp',
   'ts-refclk-media.sdp',
-  'ts-refclk-sess.sdp'
+  'ts-refclk-sess.sdp',
+  'rtcp-fb.sdp'
 ];
 
 sdps.forEach((name) => {

--- a/test/rtcp-fb.sdp
+++ b/test/rtcp-fb.sdp
@@ -1,0 +1,20 @@
+v=0
+o=alice 1957 513 IN IP4 127.0.0.1
+s=Talk
+c=IN IP4 127.0.0.1
+t=0 0
+a=rtcp-xr:rcvr-rtt=all:10000 stat-summary=loss,dup,jitt,TTL voip-metrics
+m=audio 7777 RTP/AVP 96 101
+a=rtpmap:96 opus/48000/2
+a=fmtp:96 useinbandfec=1
+a=rtpmap:101 telephone-event/48000
+a=rtcp-fb:* trr-int 5
+a=rtcp-fb:* ccm tmmbr
+m=video 8888 RTP/AVP 96
+a=rtpmap:96 VP8/90000
+a=rtcp-fb:* trr-int 5
+a=rtcp-fb:* ccm tmmbr
+a=rtcp-fb:96 nack pli
+a=rtcp-fb:96 nack sli
+a=rtcp-fb:96 ack rpsi
+a=rtcp-fb:96 ccm fir


### PR DESCRIPTION
The [RFC-4585](https://tools.ietf.org/html/rfc4585) contains description of format rtcp-fb, rtcp-fb-pt could be "\*", but in grammar.js for trr-int value rtcp-fb-pt attribute couldn't be "\*". File test/rtcp-fb.sdp contains a real SDP from Linphone.
Without this fix after parse and write SDP from test/rtcp-fb.sdp file I get a wrong SDP with attributes like this: "a=rtcp-fb:NaN trr-int 5".